### PR TITLE
Fix server installation and unwanted file deletion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "2.4"
+version = "2.5"
 group= "com.hrudyplayz.mcinstanceloader" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "mcinstanceloader"
 

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -99,6 +99,7 @@ public class Main {
 
         // ===== STEP 6: Overrides copy =====
         copyOverrides();
+        copyLocalizedOverrides();
         LogHelper.appendToLog(Level.INFO, "", true); // Adds an empty line to the log file, to make it more readable.
 
         // ===== STEP 7: Carryover copy =====
@@ -196,11 +197,24 @@ public class Main {
             // The pack directory
             FileHelper.createDirectory(path);
 
-            // The overrides directory
+            // The main overrides directory
             FileHelper.createDirectory(path + File.separator + "overrides");
-            FileHelper.overwriteFile(path + File.separator + "overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root.", "Created my MCInstance Loader."});
+            FileHelper.overwriteFile(path + File.separator + "overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root. Applies to both client-side and server-side.", "Created my MCInstance Loader."});
             FileHelper.createDirectory(path + File.separator + "overrides" + File.separator + "mods");
-            FileHelper.overwriteFile(path + File.separator + "overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder.", "Created by MCInstance Loader."});
+            FileHelper.overwriteFile(path + File.separator + "overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Applies to both client-side and server-side.", "Created by MCInstance Loader."});
+
+            // The client overrides directory
+            FileHelper.createDirectory(path + File.separator + "client_overrides");
+            FileHelper.overwriteFile(path + File.separator + "client_overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root. Client-side only", "Created my MCInstance Loader."});
+            FileHelper.createDirectory(path + File.separator + "client_overrides" + File.separator + "mods");
+            FileHelper.overwriteFile(path + File.separator + "client_overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Client-side only", "Created by MCInstance Loader."});
+
+            // The server overrides directory
+            FileHelper.createDirectory(path + File.separator + "server_overrides");
+            FileHelper.overwriteFile(path + File.separator + "server_overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root. Server-side only", "Created my MCInstance Loader."});
+            FileHelper.createDirectory(path + File.separator + "server_overrides" + File.separator + "mods");
+            FileHelper.overwriteFile(path + File.separator + "server_overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Server-side only", "Created by MCInstance Loader."});
+
 
             // The metadata.packconfig file.
             FileHelper.overwriteFile(path + File.separator + "metadata.packconfig", new String[]{
@@ -483,6 +497,38 @@ public class Main {
 
                 // Tries to move (merge) the file, if it fails it throws an error.
                 if (!FileHelper.copy(Config.configFolder + "temp" + File.separator + "overrides" + File.separator + s, s)) throwError("Error while merging the file " + s + " from the overrides folder.");
+
+                errorContext = ""; // Resets the errorContext, so it can be reused for the next resource or the next step.
+            }
+
+            ProgressManager.pop(progress); // Deletes the progressbar, as it doesn't need to be shown anymore (all files have been done).
+        }
+    }
+
+    public static void copyLocalizedOverrides() {
+        // Overrides copy: Replaces the minecraft files with the ones in the overrides folder.
+        String overrideType = (side.equals("client")) ? "client_overrides" : "server_overrides";
+
+        String path = Config.configFolder + "temp" + File.separator + overrideType;
+
+        // If there wasn't any error that occured on the previous steps.
+        if (!hasErrorOccured && !hasUpdate && FileHelper.exists(path) && FileHelper.isDirectory(path)) {
+            LogHelper.info("Moving the files from the " + overrideType + " folder.");
+
+            // Creates the recursive file list, to merge from.
+            String[] fileList = FileHelper.listDirectory(Config.configFolder + "temp" + File.separator + overrideType, true);
+
+            // Creates the forge progressbar for the current step, so it can be displayed on the loading screen.
+            ProgressManager.ProgressBar progress = ProgressManager.push("MCInstance: Merging " + overrideType + " folder", fileList.length, true);
+
+            // For every file/folder in the localized overrides folder, we move them to the root .minecraft folder.
+            for (String s : fileList) {
+                progress.step(s);
+
+                LogHelper.verboseInfo("Merging " + s + " with the original folder.");
+
+                // Tries to move (merge) the file, if it fails it throws an error.
+                if (!FileHelper.copy(Config.configFolder + "temp" + File.separator + overrideType + File.separator + s, s)) throwError("Error while merging the file " + s + " from the " + overrideType + " folder.");
 
                 errorContext = ""; // Resets the errorContext, so it can be reused for the next resource or the next step.
             }

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -160,19 +160,16 @@ public class Main {
         Config.createConfigFile();
 
         // Deletes the empty files in the mods folder, prior to an installation
-        if (FileHelper.exists(Config.configFolder + "pack.mcinstance")) {
-            String[] list = FileHelper.listDirectory("mods", true);
-            for (String s : list) {
-                long size = -1;
-                try {
-                    size = Files.size(Paths.get("mods" + File.separator + s));
-                } catch (Exception ignore) {
-                }
-
-                if (size == 0) FileHelper.delete("mods" + File.separator + s);
+        String[] list = FileHelper.listDirectory("mods", true);
+        for (String s : list) {
+            long size = -1;
+            try {
+                size = Files.size(Paths.get("mods" + File.separator + s));
             }
-        }
+            catch (Exception ignore) {}
 
+            if (size == 0 && (FileHelper.exists(Config.configFolder + "pack.mcinstance") || s.startsWith("mcinstanceloader"))) FileHelper.delete("mods" + File.separator + s);
+        }
         // If the carryover folder doesn't exist, it creates it with empty mods and config folders inside.
         if (!FileHelper.exists("carryover")) {
             LogHelper.info("The carryover folder didn't exist, created a blank one.");
@@ -204,16 +201,16 @@ public class Main {
             FileHelper.overwriteFile(path + File.separator + "overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Applies to both client-side and server-side.", "Created by MCInstance Loader."});
 
             // The client overrides directory
-            FileHelper.createDirectory(path + File.separator + "client_overrides");
-            FileHelper.overwriteFile(path + File.separator + "client_overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root. Client-side only", "Created my MCInstance Loader."});
-            FileHelper.createDirectory(path + File.separator + "client_overrides" + File.separator + "mods");
-            FileHelper.overwriteFile(path + File.separator + "client_overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Client-side only", "Created by MCInstance Loader."});
+            FileHelper.createDirectory(path + File.separator + "client-overrides");
+            FileHelper.overwriteFile(path + File.separator + "client-overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root. Client-side only", "Created my MCInstance Loader."});
+            FileHelper.createDirectory(path + File.separator + "client-overrides" + File.separator + "mods");
+            FileHelper.overwriteFile(path + File.separator + "client-overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Client-side only", "Created by MCInstance Loader."});
 
             // The server overrides directory
-            FileHelper.createDirectory(path + File.separator + "server_overrides");
-            FileHelper.overwriteFile(path + File.separator + "server_overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root. Server-side only", "Created my MCInstance Loader."});
-            FileHelper.createDirectory(path + File.separator + "server_overrides" + File.separator + "mods");
-            FileHelper.overwriteFile(path + File.separator + "server_overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Server-side only", "Created by MCInstance Loader."});
+            FileHelper.createDirectory(path + File.separator + "server-overrides");
+            FileHelper.overwriteFile(path + File.separator + "server-overrides" + File.separator + "example.txt", new String[]{"Example file that would be at root. Server-side only", "Created my MCInstance Loader."});
+            FileHelper.createDirectory(path + File.separator + "server-overrides" + File.separator + "mods");
+            FileHelper.overwriteFile(path + File.separator + "server-overrides" + File.separator + "mods" + File.separator + "example2.txt", new String[]{"Example file that would be in the mods folder. Server-side only", "Created by MCInstance Loader."});
 
 
             // The metadata.packconfig file.
@@ -447,10 +444,10 @@ public class Main {
 
                 if (!Config.verboseMode && side.equals("server")) {
                     progressCount++;
-                    LogHelper.info("Downloading " + object.name + "... | (" + progressCount + "/" + list.length + " mods)");
+                    LogHelper.info("Downloading " + object.name + "... (" + progressCount + "/" + list.length + " resources)");
                 }
 
-                LogHelper.verboseInfo("Attempting to download the resource " + object.name + " | (" + progressCount + "/" + list.length + " mods)");
+                LogHelper.verboseInfo("Attempting to download the resource " + object.name + "... (" + progressCount + "/" + list.length + " resources)");
 
                 if (object.downloadFile()) {
                     if (!object.checkHash()) throwError("Could not verify the hash of " + object.name + ".");
@@ -506,8 +503,8 @@ public class Main {
     }
 
     public static void copyLocalizedOverrides() {
-        // Overrides copy: Replaces the minecraft files with the ones in the overrides folder.
-        String overrideType = (side.equals("client")) ? "client_overrides" : "server_overrides";
+        // Overrides copy: Replaces the minecraft files with the ones in the localized overrides folder.
+        String overrideType = (side.equals("client")) ? "client-overrides" : "server-overrides";
 
         String path = Config.configFolder + "temp" + File.separator + overrideType;
 
@@ -634,7 +631,7 @@ public class Main {
 
         if (side.equals("server")) {
             LogHelper.info("Succesfully installed the mcinstance file!");
-            LogHelper.info("The server will now restart to complete the setup.");
+            LogHelper.info("The server will soon restart to apply its changes.");
 
             MinecraftServer.getServer().initiateShutdown();
             return;

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -161,6 +161,8 @@ public class Main {
 
         // Deletes the empty files in the mods folder, prior to an installation
         String[] list = FileHelper.listDirectory("mods", true);
+        LogHelper.verboseInfo("Scanning 0 byte files scheduled for deletion");
+
         for (String s : list) {
             long size = -1;
             try {
@@ -168,7 +170,12 @@ public class Main {
             }
             catch (Exception ignore) {}
 
-            if (size == 0 && (FileHelper.exists(Config.configFolder + "pack.mcinstance") || s.startsWith("mcinstanceloader"))) FileHelper.delete("mods" + File.separator + s);
+            LogHelper.verboseInfo("name: " + s + " | size: " + size);
+
+            if (size == 0 && !(FileHelper.isDirectory("mods" + File.separator + s))) {
+                FileHelper.delete("mods" + File.separator + s);
+                LogHelper.verboseInfo("Deleting file " + s);
+            }
         }
         // If the carryover folder doesn't exist, it creates it with empty mods and config folders inside.
         if (!FileHelper.exists("carryover")) {

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -158,16 +158,18 @@ public class Main {
 
         Config.createConfigFile();
 
-        // Deletes the empty files in the mods folder
-        String[] list = FileHelper.listDirectory("mods", true);
-        for (String s : list) {
-            long size = -1;
-            try {
-                size = Files.size(Paths.get("mods" + File.separator + s));
-            }
-            catch (Exception ignore) {}
+        // Deletes the empty files in the mods folder, prior to an installation
+        if (FileHelper.exists(Config.configFolder + "pack.mcinstance")) {
+            String[] list = FileHelper.listDirectory("mods", true);
+            for (String s : list) {
+                long size = -1;
+                try {
+                    size = Files.size(Paths.get("mods" + File.separator + s));
+                } catch (Exception ignore) {
+                }
 
-            if (size == 0) FileHelper.delete("mods" + File.separator + s);
+                if (size == 0) FileHelper.delete("mods" + File.separator + s);
+            }
         }
 
         // If the carryover folder doesn't exist, it creates it with empty mods and config folders inside.

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -172,13 +172,13 @@ public class Main {
 
             //Ignore folders
             if (FileHelper.isDirectory("mods" + File.separator + s))
-                return;
+                continue;
 
             LogHelper.verboseInfo("name: " + s + " | size: " + size);
 
             if (size == 0) {
-                FileHelper.delete("mods" + File.separator + s);
                 LogHelper.verboseInfo("Deleting file " + s);
+                FileHelper.delete("mods" + File.separator + s);
             }
         }
         // If the carryover folder doesn't exist, it creates it with empty mods and config folders inside.

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -413,6 +413,7 @@ public class Main {
 
             // Creates the forge progressbar for the current step, so it can be displayed on the loading screen.
             ProgressManager.ProgressBar progress = ProgressManager.push("MCInstance: Downloading resource", list.length, true);
+            int progressCount = 0;
 
             // Grabs the current list of blacklisted sites from StopModReposts.
             if (!Config.disableStopModRepostsCheck) {
@@ -430,7 +431,12 @@ public class Main {
                 LogHelper.appendToLog(Level.INFO, "==================================================", true);
                 object.appendToLog();
 
-                LogHelper.verboseInfo("Attempting to download the resource " + object.name + "...");
+                if (!Config.verboseMode && side.equals("server")) {
+                    progressCount++;
+                    LogHelper.info("Downloading " + object.name + "... | (" + progressCount + "/" + list.length + " mods)");
+                }
+
+                LogHelper.verboseInfo("Attempting to download the resource " + object.name + " | (" + progressCount + "/" + list.length + " mods)");
 
                 if (object.downloadFile()) {
                     if (!object.checkHash()) throwError("Could not verify the hash of " + object.name + ".");
@@ -582,6 +588,8 @@ public class Main {
 
         if (side.equals("server")) {
             LogHelper.info("Succesfully installed the mcinstance file!");
+            LogHelper.info("The server will now restart to complete the setup.");
+
             MinecraftServer.getServer().initiateShutdown();
             return;
         }

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
 
+import net.minecraft.server.MinecraftServer;
 import org.apache.logging.log4j.Level;
 
 import net.minecraft.client.resources.I18n;
@@ -551,7 +552,11 @@ public class Main {
 
         LogHelper.error(text); // Adds the error to the general game log and the mod log.
 
-        if (side.equals("server")) return;
+        if (side.equals("server")) {
+            LogHelper.info("Failed to install the mcinstance file!");
+            MinecraftServer.getServer().initiateShutdown();
+            return;
+        };
 
         text = "- " + text; // Formats the text to look like an error list.
 
@@ -575,6 +580,7 @@ public class Main {
 
         if (side.equals("server")) {
             LogHelper.info("Succesfully installed the mcinstance file!");
+            MinecraftServer.getServer().initiateShutdown();
             return;
         }
 

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Main.java
@@ -161,7 +161,7 @@ public class Main {
 
         // Deletes the empty files in the mods folder, prior to an installation
         String[] list = FileHelper.listDirectory("mods", true);
-        LogHelper.verboseInfo("Scanning 0 byte files scheduled for deletion");
+        LogHelper.verboseInfo("Detecting files scheduled for deletion");
 
         for (String s : list) {
             long size = -1;
@@ -170,9 +170,13 @@ public class Main {
             }
             catch (Exception ignore) {}
 
+            //Ignore folders
+            if (FileHelper.isDirectory("mods" + File.separator + s))
+                return;
+
             LogHelper.verboseInfo("name: " + s + " | size: " + size);
 
-            if (size == 0 && !(FileHelper.isDirectory("mods" + File.separator + s))) {
+            if (size == 0) {
                 FileHelper.delete("mods" + File.separator + s);
                 LogHelper.verboseInfo("Deleting file " + s);
             }
@@ -449,8 +453,9 @@ public class Main {
                 LogHelper.appendToLog(Level.INFO, "==================================================", true);
                 object.appendToLog();
 
+                progressCount++;
+
                 if (!Config.verboseMode && side.equals("server")) {
-                    progressCount++;
                     LogHelper.info("Downloading " + object.name + "... (" + progressCount + "/" + list.length + " resources)");
                 }
 

--- a/versionData.txt
+++ b/versionData.txt
@@ -1,3 +1,3 @@
-version: 2.4
-fileName: mcinstanceloader-2.4.jar
-url: https://github.com/HRudyPlayZ/MCInstanceLoader/releases/download/1.7.10-2.4/mcinstanceloader-2.4.jar
+version: 2.5
+fileName: mcinstanceloader-2.5.jar
+url: https://github.com/HRudyPlayZ/MCInstanceLoader/releases/download/1.7.10-2.5/mcinstanceloader-2.5.jar


### PR DESCRIPTION
Server will now close on successful installation or error to properly load up mods at the next start.

Prevents MCIL from deleting what it considers it to be "empty files" at every load which would often have it deleting important files. Now it shall only do so prior to an installation.