### PR TITLE
Add config to fix ignore HTTPS certificates when necessary

### DIFF
--- a/src/main/java/com/hrudyplayz/mcinstanceloader/Config.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/Config.java
@@ -27,6 +27,7 @@ public class Config {
     public static int closeGameTimer;
     public static int amountOfDisplayedErrors;
     public static String[] successMessage;
+    public static boolean allowSSLCertificateBypass;
 
     public static String CATEGORY_BEHAVIOR = "Behavior";
     public static String CATEGORY_GUI = "GUI";
@@ -47,6 +48,7 @@ public class Config {
         skipFileDisabling = config.getBoolean("Skip file disabling", CATEGORY_BEHAVIOR, false, "Whether to skip the step that disables the pack.mcinstance file and deletes the temp folder. Useful for pack devs.");
         deleteInsteadOfRenaming = config.getBoolean("Delete MCInstance directly", CATEGORY_BEHAVIOR, false, "Wheter to delete the pack.mcinstance file instead of renaming it.");
         disableStopModRepostsCheck = config.getBoolean("Disable StopModReposts check", CATEGORY_BEHAVIOR, false, "Whether to disable the StopModReposts check, used to prevent the use of malware sites. It's recommended to keep it enabled.");
+        allowSSLCertificateBypass = config.getBoolean("Allow SSL Certificate bypass", CATEGORY_BEHAVIOR, false, "Whether to allow the bypass of SSL Certificates if this cause problems. This may fix download issues in some launchers.");
         disableCache = config.getBoolean("Disable the cache system", CATEGORY_BEHAVIOR, false, "Whether to disable the cache system, forcing every resource to be downloaded regardless of the cached value.");
 
         disableAutomaticZipCreation = config.getBoolean("Disable the automatic zipping system for the pack folder", CATEGORY_BEHAVIOR, false, "Whether to disable the automatic creation of the pack.mcinstance file from the pack folder.");

--- a/src/main/java/com/hrudyplayz/mcinstanceloader/utils/WebHelper.java
+++ b/src/main/java/com/hrudyplayz/mcinstanceloader/utils/WebHelper.java
@@ -3,6 +3,10 @@ package com.hrudyplayz.mcinstanceloader.utils;
 import java.io.File;
 import java.io.IOException;
 import java.net.*;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -10,6 +14,11 @@ import org.apache.commons.io.FileUtils;
 
 import com.hrudyplayz.mcinstanceloader.Config;
 import com.hrudyplayz.mcinstanceloader.Main;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 /**
 An helper class to download files from the internet.
@@ -22,6 +31,8 @@ public class WebHelper {
     // Defines the client properties, uses Twitch UserAgents to make every website work correctly as they should.
     public static String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) twitch-desktop-electron-platform/1.0.0 Chrome/73.0.3683.121 Electron/5.0.12 Safari/537.36 desklight/8.51.0";
     public static String REFERER = "https://www.google.com";
+
+    public static Boolean checkSSLCertificates = true;
 
     /**
     Downloads a specific file from an internet address and saves it to a given location.
@@ -64,19 +75,28 @@ public class WebHelper {
 
             File file = new File(savePath);
             FileUtils.copyInputStreamToFile(connection.getInputStream(), file);
+            file.canRead();
+            if (doneIOException)
+                LogHelper.info("Successfully downloaded file on the second attempt.");
             return true;
         }
         catch (IOException e) {
             if (!doneIOException) {
-                LogHelper.info("An error occured while downloading the file, trying again...");
+                LogHelper.info("An error occurred while downloading the file, trying again...");
                 try {
                     TimeUnit.MILLISECONDS.sleep(1000);
                 }
                 catch (InterruptedException ignore) {}
 
+                if (Config.allowSSLCertificateBypass && checkSSLCertificates) {
+                    LogHelper.info("Attempting to resolve issues by bypassing SSL certificates.");
+                    disableSSLCertificateChecking();
+                }
+
                 return downloadFile(fileURL, savePath, true);
             }
             else {
+
                 Main.errorContext = "There was an issue writing to file.";
                 return false;
             }
@@ -138,5 +158,38 @@ public class WebHelper {
         }
 
         return downloadFile(fileURL, savePath);
+    }
+
+    /**
+     * Disables the SSL certificate checking for new instances of {@link HttpsURLConnection} This has been created to
+     * aid testing on a local box, not for use on production.
+     */
+    private static void disableSSLCertificateChecking() {
+        TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+                return null;
+            }
+
+            @Override
+            public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+                // Not implemented
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+                // Not implemented
+            }
+        } };
+
+        try {
+            SSLContext sc = SSLContext.getInstance("TLS");
+
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        checkSSLCertificates = false;
     }
 }


### PR DESCRIPTION
Fixes issues with pack installation on launchers such as CurseForge Launcher and AT Launcher.
However, it is disabled by default, requiring `allowSSLCertificateBypass` to be set to true in the configs.

Closes https://github.com/HRudyPlayZ/MCInstanceLoader/issues/3

